### PR TITLE
Fix the warning with the latest CMake (3.14)

### DIFF
--- a/ios.toolchain.cmake
+++ b/ios.toolchain.cmake
@@ -457,7 +457,7 @@ endif (NOT DEFINED CMAKE_INSTALL_NAME_TOOL)
 
 # Set the find root to the iOS developer roots and to user defined paths.
 set(CMAKE_FIND_ROOT_PATH ${CMAKE_IOS_DEVELOPER_ROOT} ${CMAKE_OSX_SYSROOT}
-  ${CMAKE_PREFIX_PATH} CACHE string  "iOS find search path root" FORCE)
+  ${CMAKE_PREFIX_PATH} CACHE STRING "iOS find search path root" FORCE)
 # Default to searching for frameworks first.
 set(CMAKE_FIND_FRAMEWORK FIRST)
 # Set up the default search directories for frameworks.


### PR DESCRIPTION
Thank you for your project. It is very useful!

## Warning Log
```
CMake Warning (dev) at /Users/zlargon/Github/ios-cmake/ios.toolchain.cmake:459 (set):
  implicitly converting 'string' to 'STRING' type.
Call Stack (most recent call first):
  /Users/zlargon/Github/ios-cmake/example/example-lib/build/CMakeFiles/3.14.1/CMakeSystem.cmake:6 (include)
  /Users/zlargon/Github/ios-cmake/example/example-lib/build/CMakeFiles/CMakeTmp/CMakeLists.txt:2 (project)
This warning is for project developers.  Use -Wno-dev to suppress it.
```