### PR TITLE
Remove automatic code signing

### DIFF
--- a/ios.toolchain.cmake
+++ b/ios.toolchain.cmake
@@ -365,9 +365,6 @@ endif()
 # Set Xcode property for SDKROOT as well if Xcode generator is used
 if(USED_CMAKE_GENERATOR MATCHES "Xcode")
   set(CMAKE_OSX_SYSROOT "${SDK_NAME}" CACHE INTERNAL "")
-  if(NOT DEFINED CMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM)
-    set(CMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM "123456789A")
-  endif()
 endif()
 
 # Specify minimum version of deployment target.


### PR DESCRIPTION
Fixes #86

`CMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM` needs to be set by the 
user anyway.
All a default value does is forcing the usage of a code signature on
targets.
Simply remove the default value should be sufficient to solve #86
without even breaking any existing usage.