### PR TITLE
Fixes #140

### DIFF
--- a/.github/workflows/catalyst.yml
+++ b/.github/workflows/catalyst.yml
@@ -20,7 +20,7 @@ jobs:
         xcode-version: '13.1'
     - name: Build
       run: ./.github/build.sh
-  build_with_13_1_MAC_CATALYST_ARM64:
+  build_with_13_4_MAC_CATALYST_ARM64:
     name: "Xcode version 13.4, Target macOS Catalyst on Apple Silicon [arm64] Target SDK 13.1"
     runs-on: macos-12
     env:

--- a/.github/workflows/catalyst.yml
+++ b/.github/workflows/catalyst.yml
@@ -8,11 +8,11 @@ on:
 
 jobs:
   build_with_13_1_MAC_CATALYST:
-    name: "Xcode version 13.1, Target macOS Catalyst on Apple Silicon [arm64] Target SDK 13.0"
+    name: "Xcode version 13.1, Target macOS Catalyst on Intel CPUs [x86_64] Target SDK 13.1"
     runs-on: macos-11
     env:
       PLATFORM: MAC_CATALYST
-      DEPLOYMENT_TARGET: "13.0"
+      DEPLOYMENT_TARGET: "13.1"
     steps:
     - uses: actions/checkout@v2
     - uses: maxim-lobanov/setup-xcode@v1
@@ -21,15 +21,15 @@ jobs:
     - name: Build
       run: ./.github/build.sh
   build_with_13_1_MAC_CATALYST_ARM64:
-    name: "Xcode version 13.2, Target macOS Catalyst on Intel CPUs [x86_64] Target SDK 13.0"
-    runs-on: macos-11
+    name: "Xcode version 13.4, Target macOS Catalyst on Apple Silicon [arm64] Target SDK 13.1"
+    runs-on: macos-12
     env:
       PLATFORM: MAC_CATALYST_ARM64
-      DEPLOYMENT_TARGET: "13.0"
+      DEPLOYMENT_TARGET: "13.1"
     steps:
     - uses: actions/checkout@v2
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '13.2'
+        xcode-version: '13.4'
     - name: Build
       run: ./.github/build.sh

--- a/ios.toolchain.cmake
+++ b/ios.toolchain.cmake
@@ -245,14 +245,14 @@ if(NOT DEFINED DEPLOYMENT_TARGET)
     set(DEPLOYMENT_TARGET "11.0")
   elseif(PLATFORM STREQUAL "MAC_CATALYST" OR PLATFORM STREQUAL "MAC_CATALYST_ARM64")
     # Unless specified, SDK version 13.0 is used by default as minimum target version (mac catalyst minimum requirement).
-    set(DEPLOYMENT_TARGET "13.0")
+    set(DEPLOYMENT_TARGET "13.1")
   else()
     # Unless specified, SDK version 11.0 is used by default as minimum target version (iOS, tvOS).
     set(DEPLOYMENT_TARGET "11.0")
   endif()
   message(STATUS "[DEFAULTS] Using the default min-version since DEPLOYMENT_TARGET not provided!")
-elseif(DEFINED DEPLOYMENT_TARGET AND PLATFORM MATCHES "^MAC_CATALYST" AND ${DEPLOYMENT_TARGET} VERSION_LESS "13.0")
-  message(FATAL_ERROR "Mac Catalyst builds requires a minimum deployment target of 13.0!")
+elseif(DEFINED DEPLOYMENT_TARGET AND PLATFORM MATCHES "^MAC_CATALYST" AND ${DEPLOYMENT_TARGET} VERSION_LESS "13.1")
+  message(FATAL_ERROR "Mac Catalyst builds requires a minimum deployment target of 13.1!")
 endif()
 
 # Store the DEPLOYMENT_TARGET in the cache


### PR DESCRIPTION
Seems Apple has bumped the minimum required target to 13.1 in newer versions of Xcode for Mac Catalyst.