### PR TITLE
Disable bitcode support by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ cmake --install . --config Release # Necessary to build combined library
 `APPLE_TARGET_TRIPLE` - Used by autoconf build systems. 
 
 ### Additional Options
-`-DENABLE_BITCODE=(BOOL)` - Enabled by default, specify FALSE or 0 to disable bitcode
+`-DENABLE_BITCODE=(BOOL)` - Disabled by default, specify TRUE or 1 to enable bitcode
 
 `-DENABLE_ARC=(BOOL)` - Enabled by default, specify FALSE or 0 to disable ARC
 

--- a/ios.toolchain.cmake
+++ b/ios.toolchain.cmake
@@ -91,7 +91,7 @@
 #    ON (default) = Will require "enable_language(OBJC) and/or enable_language(OBJCXX)" for full OBJC|OBJCXX support
 #    OFF = Will embed the OBJC and OBJCXX flags into the CMAKE_C_FLAGS and CMAKE_CXX_FLAGS (legacy behavior, CMake version < 3.16)
 #
-# ENABLE_BITCODE: (ON|OFF) Enables or disables bitcode support. Default ON
+# ENABLE_BITCODE: (ON|OFF) Enables or disables bitcode support. Default OFF
 #
 # ENABLE_ARC: (ON|OFF) Enables or disables ARC support. Default ON (ARC enabled by default)
 #
@@ -526,12 +526,8 @@ elseif(DEFINED CMAKE_OSX_SYSROOT_INT)
 endif()
 
 # Use bitcode or not
-if(NOT DEFINED ENABLE_BITCODE AND NOT ARCHS MATCHES "((^|;|, )(i386|x86_64))+")
-  # Unless specified, enable bitcode support by default
-  message(STATUS "[DEFAULTS] Enabling bitcode support by default. ENABLE_BITCODE not provided!")
-  set(ENABLE_BITCODE ON)
-elseif(NOT DEFINED ENABLE_BITCODE)
-  message(STATUS "[DEFAULTS] Disabling bitcode support by default on simulators. ENABLE_BITCODE not provided for override!")
+if(NOT DEFINED ENABLE_BITCODE)
+  message(STATUS "[DEFAULTS] Disabling bitcode support by default. ENABLE_BITCODE not provided for override!")
   set(ENABLE_BITCODE OFF)
 endif()
 set(ENABLE_BITCODE_INT ${ENABLE_BITCODE} CACHE BOOL


### PR DESCRIPTION
When I tried to merge compiled static libraries into a single XCFramework, `xcodebuild` errored for me with something that looks like a bitcode shorthand:

```
❯ xcodebuild -create-xcframework -library lib-ios-arm64.a -output lib.xcframework
error: unable to find any architecture information in the binary at '.../lib-ios-arm64.a': Unknown header: 0xb17c0de
```

After some research, I've found that ios-cmake enables bitcode support by default, and I don't think we'll need it after Apple officially deprecated bitcode in 2022.:

> Starting with Xcode 14, bitcode is no longer required for watchOS and tvOS applications, and the App Store no longer accepts bitcode submissions from Xcode 14.

> Xcode no longer builds bitcode by default and generates a warning message if a project explicitly enables bitcode: “Building with bitcode is deprecated. Please update your project and/or target settings to disable bitcode.” The capability to build with bitcode will be removed in a future Xcode release. IPAs that contain bitcode will have the bitcode stripped before being submitted to the App Store. Debug symbols can only be downloaded from App Store Connect / TestFlight for existing bitcode submissions and are no longer available for submissions made with Xcode 14. (86118779)

https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes

I've only changed default parameter value in this PR, but should we fully remove bitcode support instead?
