### PR TITLE
example: avoid cmake_minimum deprecation warning

### DIFF
--- a/example/example-lib/CMakeLists.txt
+++ b/example/example-lib/CMakeLists.txt
@@ -1,9 +1,6 @@
-cmake_minimum_required (VERSION 3.2)
-project (example-ios)
+cmake_minimum_required (VERSION 3.5)
+project(example-ios LANGUAGES CXX OBJC)
 enable_testing()
-
-enable_language(CXX)
-enable_language(OBJC)
 
 MESSAGE( STATUS "CMAKE_CXX_FLAGS: " ${CMAKE_CXX_FLAGS} )
 MESSAGE( STATUS "CMAKE_OBJC_FLAGS: " ${CMAKE_OBJC_FLAGS} )


### PR DESCRIPTION
Apple Silicon in general requires CMake >= 3.19.2, so it's unlikely to be an issue.

This avoids warning with CMake >= 3.27:

```sh
 % cmake -Bbuild -G Xcode -DCMAKE_TOOLCHAIN_FILE=../../ios.toolchain.cmake -DPLATFORM=OS64
 ```
 
> CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

> Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
 