### PR TITLE
Remove optimisation causing failures

### DIFF
--- a/ios.toolchain.cmake
+++ b/ios.toolchain.cmake
@@ -150,12 +150,6 @@
 
 cmake_minimum_required(VERSION 3.8.0)
 
-# CMake invokes the toolchain file twice during the first build, but only once during subsequent rebuilds.
-if(DEFINED ENV{_IOS_TOOLCHAIN_HAS_RUN})
-  return()
-endif()
-set(ENV{_IOS_TOOLCHAIN_HAS_RUN} true)
-
 # List of supported platform values
 list(APPEND _supported_platforms
         "OS" "OS64" "OS64COMBINED" "SIMULATOR" "SIMULATOR64" "SIMULATORARM64" "SIMULATOR64COMBINED"


### PR DESCRIPTION
Resolves #146.

This seems like an optimisation (it should be fine, though suboptimal, to sometimes run the toolchain twice) that breaks some use-cases (different people complained in #146). I therefore believe that it should be removed (and brought back properly if there is a need at some point).

Also @leetal said:

> I cannot remember either why i changed that in the first place... Seems to run equally good using both the "old" solution as with the ENV solution.

Seems like it should be fine to just remove it.