### PR TITLE
Removed manual arch setting for ASM

### DIFF
--- a/ios.toolchain.cmake
+++ b/ios.toolchain.cmake
@@ -992,7 +992,7 @@ else()
     set(CMAKE_OBJCXX_LINK_FLAGS "${C_TARGET_FLAGS} ${SDK_NAME_VERSION_FLAGS} -Wl,-search_paths_first ${CMAKE_OBJCXX_LINK_FLAGS}" CACHE INTERNAL
      "Flags used by the compiler for all OBJCXX link types.")
   endif()
-  set(CMAKE_ASM_FLAGS "${CMAKE_C_FLAGS} -x assembler-with-cpp -arch ${CMAKE_OSX_ARCHITECTURES} ${APPLE_TARGET_TRIPLE_FLAG}" CACHE INTERNAL
+  set(CMAKE_ASM_FLAGS "${CMAKE_C_FLAGS} -x assembler-with-cpp" CACHE INTERNAL
      "Flags used by the compiler for all ASM build types.")
 endif()
 


### PR DESCRIPTION
This fixes a problem when generating fat builds. Since `CMAKE_OSX_ARCHITECTURES` is a semicolon separated list, CMake will generate the invalid flag `--arch x86_64;arm64`, thus failing during compile. However, CMake already adds the correct space separated flags `--arch x86_64 --arch arm64`, making the whole manual setting redundant and error-prone. `APPLE_TARGET_TRIPLE_FLAG` also is redundant and can be safely remove, CMake already handles that.

I noticed this problem when trying to compile [BLAKE3](https://github.com/BLAKE3-team/BLAKE3), due to its ASM usage. Checking the Ninja file revealed the aforementioned arch flags with the semicolon list.